### PR TITLE
Forgot password styling changes

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -2,24 +2,24 @@
   <div class="grid">
     <div class="grid__item width-one-half shift-one-fourth">
       <div class="form-card form-card--compact">
+
         <div class="form-card__header">
           <h1 class="form-card__title">Password reset</h1>
           <p class="text--help">We can help. Simply enter your email address below, and we'll send you a link to reset your password.</p>
         </div>
+
+        <%= form_for resource, as: resource_name, url: password_path(resource_name), builder: GcfFormBuilder do |f| %>
         <div class="form-card__content">
-        <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-        <%= devise_error_messages! %>
-          <div class="field">
-        <%= f.label :email %><br />
-        <%= f.email_field :email, autofocus: true %>
-      </div>
-      <div class="form-card__footer">
-        <%= f.submit "Send password reset link", class: 'button button--primary nudge--med', role: 'button' %>
-      </div>
-        <% end %>
+          <%= devise_error_messages! %>
+          <%= f.gcf_input_field :email, "Email", autofocus: true, classes: ['form-width--long'] %>
         </div>
+        <div class="form-card__footer">
+          <%= f.submit "Send password reset link", class: 'button button--primary nudge--med', role: 'button' %>
+        </div>
+        <% end %>
+
       </div>
-      <%= render "devise/shared/links" %>
+    <%= render "devise/shared/links" %>
     </div>
   </div>
 </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,18 +1,22 @@
 <div class="slab">
   <div class="grid">
-    <div class="grid__item width-two-thirds shift-one-sixth">
-      <div class="form-card">
-          <h1 class="form-card__title">Forgot your password?</h1>
-          <p class="text--help">We can help — simply enter your email address below, and we'll send you a link to create a new password.</p>
-        <div class="form-card__content nudge--med">
-        
+    <div class="grid__item width-one-half shift-one-fourth">
+      <div class="form-card form-card--compact">
+      	<div class="form-card__header">
+          <h1 class="form-card__title">Password reset</h1>
+          <p class="text--help">We can help — simply enter your email address below, and we'll send you a link to reset your password.</p>
+        </div>
+        <div class="form-card__content">
         <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   			<%= devise_error_messages! %>
           <div class="field">
     		<%= f.label :email %><br />
    			<%= f.email_field :email, autofocus: true %>
   		</div>
-         <%= f.submit "Send password reset instructions", class: 'button button--cta nudge--med', role: 'button' %>
+  		<div class="form-card__footer">
+  			<%= f.submit "Send password reset link", class: 'button button--primary nudge--med', role: 'button' %>
+  		</div>
+         
         <% end %>
         </div>
       </div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,22 @@
-<h2>Forgot your password?</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+<div class="slab">
+  <div class="grid">
+    <div class="grid__item width-two-thirds shift-one-sixth">
+      <div class="form-card">
+          <h1 class="form-card__title">Forgot your password?</h1>
+          <p class="text--help">We can help — simply enter your email address below, and we'll send you a link to create a new password.</p>
+        <div class="form-card__content nudge--med">
+        
+        <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  			<%= devise_error_messages! %>
+          <div class="field">
+    		<%= f.label :email %><br />
+   			<%= f.email_field :email, autofocus: true %>
+  		</div>
+         <%= f.submit "Send password reset instructions", class: 'button button--cta nudge--med', role: 'button' %>
+        <% end %>
+        </div>
+      </div>
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -2,21 +2,20 @@
   <div class="grid">
     <div class="grid__item width-one-half shift-one-fourth">
       <div class="form-card form-card--compact">
-      	<div class="form-card__header">
+        <div class="form-card__header">
           <h1 class="form-card__title">Password reset</h1>
-          <p class="text--help">We can help — simply enter your email address below, and we'll send you a link to reset your password.</p>
+          <p class="text--help">We can help. Simply enter your email address below, and we'll send you a link to reset your password.</p>
         </div>
         <div class="form-card__content">
         <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  			<%= devise_error_messages! %>
+        <%= devise_error_messages! %>
           <div class="field">
-    		<%= f.label :email %><br />
-   			<%= f.email_field :email, autofocus: true %>
-  		</div>
-  		<div class="form-card__footer">
-  			<%= f.submit "Send password reset link", class: 'button button--primary nudge--med', role: 'button' %>
-  		</div>
-         
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true %>
+      </div>
+      <div class="form-card__footer">
+        <%= f.submit "Send password reset link", class: 'button button--primary nudge--med', role: 'button' %>
+      </div>
         <% end %>
         </div>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,9 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Clientcomm</title>
+    <title>ClientComm</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all' %>


### PR DESCRIPTION
- Realized that if we're going to use the 'forgot-password' page as a way to have users set up passwords (per #17), I should take a pass at the UI to make sure it looks okay. These changes make the page look more like GCF's forgot-password page.
- Also changed site-wide title to "ClientComm"