### PR TITLE
Fixes `sendbar` on message page

### DIFF
--- a/app/assets/stylesheets/molecules/_sendbar.scss
+++ b/app/assets/stylesheets/molecules/_sendbar.scss
@@ -25,7 +25,6 @@
 
   @extend .button;
   display: table-cell;
-  vertical-align: middle;
   appearance: none;
   width: 1%;
   border: 2px solid $color-teal;

--- a/app/assets/stylesheets/templates/_messages.scss
+++ b/app/assets/stylesheets/templates/_messages.scss
@@ -86,7 +86,6 @@
     bottom: 0;
     left: 0;
     padding: 0 5px;
-    display: flex;
     align-items: center;
     white-space: nowrap;
     color: #999;
@@ -100,6 +99,10 @@
     padding: {
       padding-left: 0;
       padding-right: 0;
+    }
+
+    .sendbar {
+      margin-top: .5em;
     }
   }
 

--- a/app/helpers/gcf_form_builder.rb
+++ b/app/helpers/gcf_form_builder.rb
@@ -13,7 +13,7 @@ class GcfFormBuilder < ActionView::Helpers::FormBuilder
     classes = classes.append(%w[sendbar__input])
     <<-HTML.html_safe
       #{text_field(method, { autofocus: autofocus, type: "text", class: classes.join(' '), autocomplete: 'off', autocorrect: 'off', autocapitalize: 'off', spellcheck: 'false', placeholder: placeholder }.merge(options))}
-      <button id="send_message" class="sendbar__button" type="submit" data-disable-with="Sending...">#{button_text}</button>
+      <label class="sendbar__button">#{button_text}<button id="send_message" type="submit"></button></label>
     HTML
   end
 

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -17,11 +17,11 @@
 
 <section class="message--create">
   <div class="grid">
-    <div class="grid__item">
-    <%= form_for @message, remote: true, :html => {:class => "sendbar form-width--searchbar"}, builder: GcfFormBuilder do |f| %>
+    <div class="grid__item width-two-thirds shift-one-sixth">
+      <%= form_for @message, remote: true, :html => {:class => "sendbar form-width--searchbar"}, builder: GcfFormBuilder do |f| %>
       <%= f.gcf_send_message_field :body, "Send", autofocus: true, placeholder: "Send a text message" %>
       <input name="client_id" type="hidden" value="<%= @client.id %>">
-    <% end %>
+      <% end %>
     </div>
   </div>
 </section>


### PR DESCRIPTION
When we merged master into the last message-styling branch, the sendbar got wonky at desktop and mobile. This PR fixes the sendbar styling, and makes it responsive. Unfortunately, it also gets rid of the "Sending..." message after a message is submitted — in the interest of time (and with my very limited engineering skills!) I couldn't figure out how to make that work, and reverted back to putting the button inside of a `<label>`.

**Desktop**
![screenshot 2017-06-05 13 46 08](https://cloud.githubusercontent.com/assets/5083453/26802444/5e2ef924-49f5-11e7-984d-1fe4d9a1e19e.png)

**Mobile**
<img width="348" alt="screenshot 2017-06-05 13 46 01" src="https://cloud.githubusercontent.com/assets/5083453/26802487/854d3bc4-49f5-11e7-8aa6-ca13d96f673d.png">
