### PR TITLE
Enable spellcheck for texting input

### DIFF
--- a/app/helpers/gcf_form_builder.rb
+++ b/app/helpers/gcf_form_builder.rb
@@ -12,7 +12,7 @@ class GcfFormBuilder < ActionView::Helpers::FormBuilder
   def gcf_send_message_field(method, button_text, options: {}, classes: [], placeholder: nil, autofocus: nil)
     classes = classes.append(%w[sendbar__input])
     <<-HTML.html_safe
-      #{text_field(method, { autofocus: autofocus, type: "text", class: classes.join(' '), autocomplete: 'off', autocorrect: 'off', autocapitalize: 'off', spellcheck: 'false', placeholder: placeholder }.merge(options))}
+      #{text_field(method, { autofocus: autofocus, type: "text", class: classes.join(' '), autocomplete: 'off', autocorrect: 'off', autocapitalize: 'off', placeholder: placeholder }.merge(options))}
       <label class="sendbar__button">#{button_text}<button id="send_message" type="submit"></button></label>
     HTML
   end


### PR DESCRIPTION
Remove code that turns off spell check in message input. I'm curious why this was here. Also, I'm curious why we have this form builder method when this is only used once. I'd be in favor of just making this inline in views/messages/index.html.erb.

flagging @alsomanya as well