### PR TITLE
Receive pictures from clients

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'device_detector'
 gem 'twilio-ruby'
 gem 'intercom-rails'
 gem 'devise'
+gem 'aws-sdk'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,14 @@ GEM
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
+    aws-sdk (2.9.42)
+      aws-sdk-resources (= 2.9.42)
+    aws-sdk-core (2.9.42)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.9.42)
+      aws-sdk-core (= 2.9.42)
+    aws-sigv4 (1.0.0)
     bcrypt (3.1.11)
     bindex (0.5.0)
     bourbon (4.2.7)
@@ -113,6 +121,7 @@ GEM
     jbuilder (2.6.4)
       activesupport (>= 3.0.0)
       multi_json (>= 1.2)
+    jmespath (1.3.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -285,6 +294,7 @@ PLATFORMS
 
 DEPENDENCIES
   addressable
+  aws-sdk
   bourbon (~> 4.2.0)
   byebug
   capybara

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,5 +1,35 @@
-
 $(document).on('submit', '#new_message', function(e) {
   // clear the message body text field
   $('#message_body').val('');
+});
+
+// placement icon
+var iconSVG =
+  "<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 {{w}} {{h}}'><defs><symbol id='a' viewBox='0 0 90 66' opacity='0.3'><path d='M85 5v56H5V5h80m5-5H0v66h90V0z'/><circle cx='18' cy='20' r='6'/><path d='M56 14L37 39l-8-6-17 23h67z'/></symbol></defs><use xlink:href='#a' width='20%' x='40%'/></svg>";
+
+$(document).ready(function() {
+  $(".attachment-img").each(function() {
+    var $this = $(this),
+      data = $this.data(), // Get all the data attributes
+      $img = $("<img />")
+        .attr({
+          width: data.width,
+          height: data.height,
+          // Set src to temporary SVG with proper viewBox
+          src: "data:image/svg+xml;charset=utf-8," +
+            encodeURIComponent(
+              iconSVG.replace(/{{w}}/g, data.width).replace(/{{h}}/g, data.height)
+            )
+        })
+        .appendTo($this)
+        // Load image on click
+        .load(function() {
+          $img.attr({
+            src: data.src, // Set the src to the real image
+            class: "",
+            title: "" // clear out our temporary attributes
+          });
+        });
+  });
+  $(document).scrollTop($('#message-list').prop('scrollHeight'));
 });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -2,34 +2,3 @@ $(document).on('submit', '#new_message', function(e) {
   // clear the message body text field
   $('#message_body').val('');
 });
-
-// placement icon
-var iconSVG =
-  "<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 {{w}} {{h}}'><defs><symbol id='a' viewBox='0 0 90 66' opacity='0.3'><path d='M85 5v56H5V5h80m5-5H0v66h90V0z'/><circle cx='18' cy='20' r='6'/><path d='M56 14L37 39l-8-6-17 23h67z'/></symbol></defs><use xlink:href='#a' width='20%' x='40%'/></svg>";
-
-$(document).ready(function() {
-  $(".attachment-img").each(function() {
-    var $this = $(this),
-      data = $this.data(), // Get all the data attributes
-      $img = $("<img />")
-        .attr({
-          width: data.width,
-          height: data.height,
-          // Set src to temporary SVG with proper viewBox
-          src: "data:image/svg+xml;charset=utf-8," +
-            encodeURIComponent(
-              iconSVG.replace(/{{w}}/g, data.width).replace(/{{h}}/g, data.height)
-            )
-        })
-        .appendTo($this)
-        // Load image on click
-        .load(function() {
-          $img.attr({
-            src: data.src, // Set the src to the real image
-            class: "",
-            title: "" // clear out our temporary attributes
-          });
-        });
-  });
-  $(document).scrollTop($('#message-list').prop('scrollHeight'));
-});

--- a/app/assets/stylesheets/templates/_messages.scss
+++ b/app/assets/stylesheets/templates/_messages.scss
@@ -28,7 +28,7 @@
       flex-basis: 55%;
       margin-left: auto;
 
-      .message__content {
+      .message--content {
         background: $color-teal;
         border-radius: 8px;
         color: $color-background;
@@ -42,7 +42,7 @@
         text-align: right;
       }
 
-      .message__label {
+      .message--label {
         background-color: $color-background;
         color: $color-grey;
         font-size: $font-size-smallest;
@@ -60,7 +60,7 @@
       align-self: flex-start;
       flex-basis: 55%;
 
-      .message__content {
+      .message--content {
         background: $color-light-grey;
         border-radius: 6px;
         margin-bottom: 10px;
@@ -72,7 +72,7 @@
         }
       }
 
-      .message__label {
+      .message--label {
         background-color: $color-background;
         color: $color-grey;
         font-size: $font-size-smallest;

--- a/app/assets/stylesheets/templates/_messages.scss
+++ b/app/assets/stylesheets/templates/_messages.scss
@@ -24,11 +24,6 @@
       max-width: 100%;
     }
 
-    figure {
-      padding: 0;
-      margin: 1em 0;
-    }
-
     .message--outbound {
       flex-basis: 55%;
       margin-left: auto;

--- a/app/assets/stylesheets/templates/_messages.scss
+++ b/app/assets/stylesheets/templates/_messages.scss
@@ -2,10 +2,12 @@
 
   .slab--header {
     padding: {
-      top: 1em;
       bottom: .5em;
+      top: 1em;
     }
-    h2, p {
+
+    h2,
+    p {
       margin-bottom: 0;
     }
   }
@@ -14,54 +16,54 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    max-width: 750px;
     margin-bottom: 1em;
-    
+    max-width: 750px;
+
     .message--outbound {
-      margin-left: auto;
       flex-basis: 55%;
-    
+      margin-left: auto;
+
       .message__content {
         background: $color-teal;
-        text-align: right;
-        color: $color-background;
         border-radius: 8px;
-        padding: {
-          right: $padding-small;
-          left: $padding-small;
-          top: $padding-small;
-          bottom: .5em;
-        }
+        color: $color-background;
         margin-bottom: 10px;
+        padding: {
+          bottom: .5em;
+          left: $padding-small;
+          right: $padding-small;
+          top: $padding-small;
+        }
+        text-align: right;
       }
 
       .message__label {
-        text-align: right;
         background-color: $color-background;
         color: $color-grey;
         font-size: $font-size-smallest;
         font-weight: 500;
-        padding: .5em;
         line-height: 1.4em;
-        top: -.1em;
         margin-left: .2em;
         margin-top: -.5em;
+        padding: .5em;
+        text-align: right;
+        top: -.1em;
       }
     }
-    
+
     .message--inbound {
       align-self: flex-start;
       flex-basis: 55%;
 
       .message__content {
-        border-radius: 6px;
         background: $color-light-grey;
+        border-radius: 6px;
         margin-bottom: 10px;
         padding: {
+          bottom: .5em;
           left: $padding-small;
           right: $padding-small;
           top: $padding-small;
-          bottom: .5em;
         }
       }
 
@@ -70,36 +72,28 @@
         color: $color-grey;
         font-size: $font-size-smallest;
         font-weight: 500;
-        padding: .5em;
         line-height: 1.4em;
-        top: -.1em;
         margin-left: .2em;
         margin-top: -.5em;
+        padding: .5em;
+        top: -.1em;
       }
     }
   }
 
   .message--create {
-    height: 80px;
-    position: fixed;
-    width: 100%;
-    bottom: 0;
-    left: 0;
-    padding: 0 5px;
     align-items: center;
-    white-space: nowrap;
-    color: #999;
     background: $color-background;
     border-top: 2px solid $color-light-grey;
+    bottom: 0;
+    color: #999;
+    height: 80px;
+    left: 0;
+    padding: 0 5px;
+    position: fixed;
+    white-space: nowrap;
+    width: 100%;
     z-index: 10;
-    margin: {
-      margin-left: 0;
-      margin-right: 0;
-    }
-    padding: {
-      padding-left: 0;
-      padding-right: 0;
-    }
 
     .sendbar {
       margin-top: .5em;

--- a/app/assets/stylesheets/templates/_messages.scss
+++ b/app/assets/stylesheets/templates/_messages.scss
@@ -19,6 +19,16 @@
     margin-bottom: 1em;
     max-width: 750px;
 
+    img {
+      height: auto;
+      max-width: 100%;
+    }
+
+    figure {
+      padding: 0;
+      margin: 1em 0;
+    }
+
     .message--outbound {
       flex-basis: 55%;
       margin-left: auto;

--- a/app/controllers/twilio_controller.rb
+++ b/app/controllers/twilio_controller.rb
@@ -2,27 +2,8 @@ class TwilioController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def incoming_sms
-    # get the client based on the phone number
-    client = Client.find_by!(phone_number: params[:From])
-    # create a new message
-    new_message_params = {
-      client: client,
-      user_id: client.user_id,
-      number_to: ENV['TWILIO_PHONE_NUMBER'],
-      number_from: params[:From],
-      inbound: true,
-      twilio_sid: params[:SmsSid],
-      twilio_status: params[:SmsStatus],
-      body: params[:Body]
-    }
-    new_message = Message.create!(new_message_params)
-
-    params[:NumMedia].to_i.times.each do |i|
-      new_message.attachments.create!({
-        url: params["MediaUrl#{i}"],
-        content_type: params["MediaContentType#{i}"]
-      })
-    end
+    new_message = Message.create_from_twilio! params
+    client = new_message.client
 
     # queue message and notification broadcasts
     MessageBroadcastJob.perform_later(message: new_message, is_update: false)

--- a/app/controllers/twilio_controller.rb
+++ b/app/controllers/twilio_controller.rb
@@ -3,7 +3,7 @@ class TwilioController < ApplicationController
 
   def incoming_sms
     # get the client based on the phone number
-    client = Client.find_by(phone_number: params[:From])
+    client = Client.find_by!(phone_number: params[:From])
     # create a new message
     new_message_params = {
       client: client,
@@ -15,7 +15,7 @@ class TwilioController < ApplicationController
       twilio_status: params[:SmsStatus],
       body: params[:Body]
     }
-    new_message = Message.create(new_message_params)
+    new_message = Message.create!(new_message_params)
 
     # queue message and notification broadcasts
     MessageBroadcastJob.perform_later(message: new_message, is_update: false)

--- a/app/controllers/twilio_controller.rb
+++ b/app/controllers/twilio_controller.rb
@@ -17,6 +17,13 @@ class TwilioController < ApplicationController
     }
     new_message = Message.create!(new_message_params)
 
+    params[:NumMedia].to_i.times.each do |i|
+      new_message.attachments.create!({
+        url: params["MediaUrl#{i}"],
+        content_type: params["MediaContentType#{i}"]
+      })
+    end
+
     # queue message and notification broadcasts
     MessageBroadcastJob.perform_later(message: new_message, is_update: false)
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -1,0 +1,3 @@
+class Attachment < ApplicationRecord
+  belongs_to :message
+end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,6 +1,7 @@
 class Client < ApplicationRecord
   belongs_to :user
   has_many :messages
+  has_many :attachments, through: :messages
 
   def analytics_tracker_data
     {
@@ -10,7 +11,8 @@ class Client < ApplicationRecord
       hours_since_contact: hours_since_contact,
       messages_all_count: messages.count,
       messages_received_count: inbound_messages_count,
-      messages_sent_count: outbound_messages_count
+      messages_sent_count: outbound_messages_count,
+      messages_attachments_count: attachments.count
     }
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -11,7 +11,33 @@ class Message < ApplicationRecord
   OUTBOUND = 'outbound'
   READ = 'read'
   UNREAD = 'unread'
-  
+ 
+  def self.create_from_twilio!(twilio_params)
+    # get the client based on the phone number
+    client = Client.find_by!(phone_number: twilio_params[:From])
+    # create a new message
+    new_message_params = {
+      client: client,
+      user_id: client.user_id,
+      number_to: ENV['TWILIO_PHONE_NUMBER'],
+      number_from: twilio_params[:From],
+      inbound: true,
+      twilio_sid: twilio_params[:SmsSid],
+      twilio_status: twilio_params[:SmsStatus],
+      body: twilio_params[:Body]
+    }
+    new_message = Message.create!(new_message_params)
+
+    twilio_params[:NumMedia].to_i.times.each do |i|
+      new_message.attachments.create!({
+        url: twilio_params["MediaUrl#{i}"],
+        content_type: twilio_params["MediaContentType#{i}"]
+      })
+    end
+
+    new_message
+  end
+
   def analytics_tracker_data
     {
       client_id: self.client.id,

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,6 +1,7 @@
 class Message < ApplicationRecord
   belongs_to :client
   belongs_to :user
+  has_many :attachments
 
   scope :inbound, -> { where(inbound: true) }
   scope :outbound, -> { where(inbound: false) }

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -43,7 +43,8 @@ class Message < ApplicationRecord
       client_id: self.client.id,
       message_id: self.id,
       message_length: self.body.length,
-      current_user_id: self.user.id
+      current_user_id: self.user.id,
+      attachments_count: self.attachments.count
     }
   end
 

--- a/app/views/attachments/_attachment.html.erb
+++ b/app/views/attachments/_attachment.html.erb
@@ -1,0 +1,1 @@
+<img src="<%= attachment.url %>" />

--- a/app/views/attachments/_attachment.html.erb
+++ b/app/views/attachments/_attachment.html.erb
@@ -1,3 +1,1 @@
-<figure class="attachment-img" data-src="<%= attachment.url %>" data-width="1536" data-height="2048">
-  <noscript><img src="<%= attachment.url %>" width="1536" height="2048" /></noscript>
-</figure>
+<img src="<%= attachment.url %>" />

--- a/app/views/attachments/_attachment.html.erb
+++ b/app/views/attachments/_attachment.html.erb
@@ -1,1 +1,3 @@
-<img src="<%= attachment.url %>" />
+<figure class="attachment-img" data-src="<%= attachment.url %>" data-width="1536" data-height="2048">
+  <noscript><img src="<%= attachment.url %>" width="1536" height="2048" /></noscript>
+</figure>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,4 +1,6 @@
 <div class="message--<%= message_inbound_or_outbound(message) %>" id="<%= dom_id(message) %>">
-  <p class="message__content"><%= message.body %></p>
+  <p class="message__content"><%= message.body %>
+  <%= render message.attachments %>
+  </p>
   <p class="message__label"><%= message.twilio_status %> <%= message.created_at.to_s(:message_timestamp) %></p>    
 </div>  

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,6 +1,6 @@
 <div class="message--<%= message_inbound_or_outbound(message) %>" id="<%= dom_id(message) %>">
-  <div class="message__content"><%= message.body %>
+  <div class="message--content"><%= message.body %>
   <%= render message.attachments %>
   </div>
-  <p class="message__label"><%= message.twilio_status %> <%= message.created_at.to_s(:message_timestamp) %></p>    
+  <p class="message--label"><%= message.twilio_status %> <%= message.created_at.to_s(:message_timestamp) %></p>    
 </div>  

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,6 +1,6 @@
 <div class="message--<%= message_inbound_or_outbound(message) %>" id="<%= dom_id(message) %>">
-  <p class="message__content"><%= message.body %>
+  <div class="message__content"><%= message.body %>
   <%= render message.attachments %>
-  </p>
+  </div>
   <p class="message__label"><%= message.twilio_status %> <%= message.created_at.to_s(:message_timestamp) %></p>    
 </div>  

--- a/db/migrate/20170619175734_create_attachments.rb
+++ b/db/migrate/20170619175734_create_attachments.rb
@@ -1,0 +1,11 @@
+class CreateAttachments < ActiveRecord::Migration[5.0]
+  def change
+    create_table :attachments do |t|
+      t.string :url, null:false
+      t.string :content_type
+      t.references :message, foreign_key: true, null: false
+      t.integer :height
+      t.integer :width
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170608050028) do
+ActiveRecord::Schema.define(version: 20170619175734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "attachments", force: :cascade do |t|
+    t.string  "url",          null: false
+    t.string  "content_type"
+    t.integer "message_id",   null: false
+    t.integer "height"
+    t.integer "width"
+    t.index ["message_id"], name: "index_attachments_on_message_id", using: :btree
+  end
 
   create_table "clients", force: :cascade do |t|
     t.string   "first_name"
@@ -77,6 +86,7 @@ ActiveRecord::Schema.define(version: 20170608050028) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "attachments", "messages"
   add_foreign_key "clients", "users"
   add_foreign_key "messages", "clients"
   add_foreign_key "messages", "users"

--- a/spec/factories/attachments.rb
+++ b/spec/factories/attachments.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :attachment do
+    url { "https://api.twilio.com/2010-04-01/Accounts/" + SecureRandom.hex(17) +
+      "/Messages/" + SecureRandom.hex(17) +
+      "/Media/" + SecureRandom.hex(17) }
+    content_type { ["image/jpeg", "image/png", "image/gif"].sample }
+    message { create :message }
+    width { [640, 800, 1024].sample }
+    height { (width * 0.75).to_i }
+  end
+end

--- a/spec/features/twilio_posts_new_message_with_attachments_spec.rb
+++ b/spec/features/twilio_posts_new_message_with_attachments_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+feature 'Twilio' do
+  after do
+    page.driver.header 'X-Twilio-Signature', nil
+  end
+
+  describe 'POSTs to #incoming_sms' do
+    context 'with attachments' do
+      it 'displays the attachments on the page' do
+        user = create :user
+        login_as(user, :scope => :user)
+        twilio_params = twilio_new_message_params media_count: 1
+        client = create :client, user: user, phone_number: twilio_params['From']
+        twilio_post_sms twilio_params
+        expect(page).to have_http_status(:no_content)
+        visit client_messages_path client
+        expect(page).to have_css %Q|.message--inbound img[src="#{twilio_params['MediaUrl0']}"]|
+      end
+    end
+  end
+end

--- a/spec/features/twilio_posts_status_update_spec.rb
+++ b/spec/features/twilio_posts_status_update_spec.rb
@@ -1,24 +1,22 @@
 require 'rails_helper'
 
 feature 'Twilio' do
+  let(:message_params) { twilio_new_message_params }
+
   before do
-    user = create :user
-    client = create :client, user: user, phone_number: params['From']
-    create :message, user: user, client: client, twilio_sid: '49a5057738d311581dd5d005e97c2b5d0b', twilio_status: 'queued'
+    userone = create :user
+    clientone = create :client, user: userone, phone_number: message_params['From']
+    create :message, user: userone, client: clientone, twilio_sid: message_params['SmsSid'], twilio_status: message_params['SmsStatus']
   end
 
   after do
-    page.driver.header 'X-Twilio-Signature', nil
-  end
-
-  let(:params) do
-    {"SmsSid"=>"49a5057738d311581dd5d005e97c2b5d0b", "SmsStatus"=>"delivered", "MessageStatus"=>"delivered", "To"=>"+12435551212", "MessageSid"=>"49a5057738d311581dd5d005e97c2b5d0b", "AccountSid"=>"077541f41cce52ea6c4944fa6823a4a277", "From"=>"+12425551212", "ApiVersion"=>"2010-04-01", "controller"=>"twilio", "action"=>"incoming_sms_status"}
+    twilio_clear_after
   end
 
   describe 'POSTs to #incoming_sms_status' do
     context 'with incorrect signature' do
       it 'returns a forbidden response' do
-        page.driver.post '/incoming/sms/status', params
+        page.driver.post '/incoming/sms/status', message_params
         expect(page).to have_http_status(:forbidden)
       end
     end
@@ -27,12 +25,12 @@ feature 'Twilio' do
       let(:correct_signature) do
         myhost = Capybara.current_host || Capybara.default_host
         Twilio::Util::RequestValidator.new(ENV['TWILIO_AUTH_TOKEN'])
-          .build_signature_for("#{myhost}/incoming/sms/status", params)
+          .build_signature_for("#{myhost}/incoming/sms/status", message_params)
       end
 
       it 'returns a no content response' do
         page.driver.header 'X-Twilio-Signature', correct_signature
-        page.driver.post '/incoming/sms/status', params
+        page.driver.post '/incoming/sms/status', message_params
         expect(page).to have_http_status(:no_content)
       end
     end

--- a/spec/features/twilio_posts_status_update_spec.rb
+++ b/spec/features/twilio_posts_status_update_spec.rb
@@ -6,7 +6,7 @@ feature 'Twilio' do
   before do
     userone = create :user
     clientone = create :client, user: userone, phone_number: message_params['From']
-    create :message, user: userone, client: clientone, twilio_sid: message_params['SmsSid'], twilio_status: message_params['SmsStatus']
+    create :message, user: userone, client: clientone, twilio_sid: message_params['SmsSid'], twilio_status: 'queued'
   end
 
   after do
@@ -16,21 +16,15 @@ feature 'Twilio' do
   describe 'POSTs to #incoming_sms_status' do
     context 'with incorrect signature' do
       it 'returns a forbidden response' do
-        page.driver.post '/incoming/sms/status', message_params
+        # send false as 2nd argument to send bad signature
+        twilio_post_sms_status message_params, false
         expect(page).to have_http_status(:forbidden)
       end
     end
 
     context 'with correct signature' do
-      let(:correct_signature) do
-        myhost = Capybara.current_host || Capybara.default_host
-        Twilio::Util::RequestValidator.new(ENV['TWILIO_AUTH_TOKEN'])
-          .build_signature_for("#{myhost}/incoming/sms/status", message_params)
-      end
-
       it 'returns a no content response' do
-        page.driver.header 'X-Twilio-Signature', correct_signature
-        page.driver.post '/incoming/sms/status', message_params
+        twilio_post_sms_status message_params
         expect(page).to have_http_status(:no_content)
       end
     end

--- a/spec/features/user_doesnt_get_alerted_about_read_messages_spec.rb
+++ b/spec/features/user_doesnt_get_alerted_about_read_messages_spec.rb
@@ -17,7 +17,7 @@ feature "User receives messages from a client" do
   context "while on the clients page" do
     it "sees a notification for only new messages from a client", :js do
       # post a message to the twilio endpoint from a user
-      twilio_post_sms(twilio_new_message_params(clientone.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clientone.phone_number))
       # there's a flash with the correct content
       flash_text = "You have 1 unread message from #{clientone.full_name}"
       expect(page).to have_css '.flash p', text: flash_text
@@ -29,7 +29,7 @@ feature "User receives messages from a client" do
       # return to the clients page
       visit clients_path
       # post a second message
-      twilio_post_sms(twilio_new_message_params(clientone_record.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clientone_record.phone_number))
       # we should see the same flash message, because the first
       # message was marked read
       expect(page).to have_css '.flash p', text: flash_text

--- a/spec/features/user_gets_notification_when_message_received_spec.rb
+++ b/spec/features/user_gets_notification_when_message_received_spec.rb
@@ -50,7 +50,7 @@ feature "User receives a message from a client" do
       # post a message to the twilio endpoint from the user
       twilio_post_sms(twilio_new_message_params(from_number: clientone.phone_number))
       # there's a message with the correct contents
-      expect(page).to have_css '.message--inbound p', text: twilio_message_text
+      expect(page).to have_css '.message--inbound div', text: twilio_message_text
       # there's no flash notification
       expect(page).to have_no_css '.flash'
     end

--- a/spec/features/user_gets_notification_when_message_received_spec.rb
+++ b/spec/features/user_gets_notification_when_message_received_spec.rb
@@ -20,7 +20,7 @@ feature "User receives a message from a client" do
   context "while on the clients page" do
     it "and sees a notification for a new message", :js do
       # post a message to the twilio endpoint from the user
-      twilio_post_sms(twilio_new_message_params(clientone.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clientone.phone_number))
       # there's a flash with the correct contents
       expect(page).to have_css '.flash p', text: "You have 1 unread message from #{clientone.full_name}"
     end
@@ -28,14 +28,14 @@ feature "User receives a message from a client" do
     it "and sees a refreshed client list", :js do
       # post a message to the twilio endpoint from the first user 5 minutes ago
       travel_to 5.minutes.ago do
-        twilio_post_sms(twilio_new_message_params(clientone.phone_number))
+        twilio_post_sms(twilio_new_message_params(from_number: clientone.phone_number))
       end
       # validate the order of the clients in the list
       visit clients_path
       expect(page).to have_css '.unread td', text: clientone.full_name
       expect(page.body.index(clientone.full_name)).to be < page.body.index(clienttwo.full_name)
       # send a message from client two and check the new order
-      twilio_post_sms(twilio_new_message_params(clienttwo.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clienttwo.phone_number))
       expect(page).to have_css '.flash p', text: "You have 2 unread messages"
       expect(page).to have_css '.unread td', text: clienttwo.full_name
       expect(page.body.index(clienttwo.full_name)).to be < page.body.index(clientone.full_name)
@@ -48,7 +48,7 @@ feature "User receives a message from a client" do
       myclient_id = Client.find_by(phone_number: PhoneNumberParser.normalize(clientone.phone_number)).id
       visit client_messages_path(client_id: myclient_id)  
       # post a message to the twilio endpoint from the user
-      twilio_post_sms(twilio_new_message_params(clientone.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clientone.phone_number))
       # there's a message with the correct contents
       expect(page).to have_css '.message--inbound p', text: twilio_message_text
       # there's no flash notification

--- a/spec/features/user_gets_notification_with_message_count_spec.rb
+++ b/spec/features/user_gets_notification_with_message_count_spec.rb
@@ -18,9 +18,9 @@ feature "User receives messages from clients" do
   context "while on the clients page" do
     it "sees a notification for new messages from one client", :js do
       # post messages to the twilio endpoint from a user
-      twilio_post_sms(twilio_new_message_params(clientone.phone_number))
-      twilio_post_sms(twilio_new_message_params(clientone.phone_number))
-      twilio_post_sms(twilio_new_message_params(clientone.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clientone.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clientone.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clientone.phone_number))
       # there's a flash with the correct contents
       expect(page).to have_css '.flash p', text: "You have 3 unread messages from #{clientone.full_name}"
     end
@@ -32,11 +32,11 @@ feature "User receives messages from clients" do
       add_client(clienttwo)
       # end up on the clients page
       expect(current_path).to eq clients_path
-      twilio_post_sms(twilio_new_message_params(clientone.phone_number))
-      twilio_post_sms(twilio_new_message_params(clienttwo.phone_number))
-      twilio_post_sms(twilio_new_message_params(clienttwo.phone_number))
-      twilio_post_sms(twilio_new_message_params(clientone.phone_number))
-      twilio_post_sms(twilio_new_message_params(clienttwo.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clientone.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clienttwo.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clienttwo.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clientone.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clienttwo.phone_number))
       # there's a flash with the correct contents
       expect(page).to have_css '.flash p', text: "You have 5 unread messages"
     end

--- a/spec/features/user_receives_new_message_marked_read_spec.rb
+++ b/spec/features/user_receives_new_message_marked_read_spec.rb
@@ -17,7 +17,7 @@ feature "User receives a message from a client" do
       # post a message to the twilio endpoint from the user
       twilio_post_sms(twilio_new_message_params(from_number: clientone.phone_number))
       # there's a message with the correct contents
-      expect(page).to have_css '.message--inbound p', text: twilio_message_text, wait: 10
+      expect(page).to have_css '.message--inbound div', text: twilio_message_text, wait: 10
       wait_for_ajax
       # now load the message index
       visit clients_path

--- a/spec/features/user_receives_new_message_marked_read_spec.rb
+++ b/spec/features/user_receives_new_message_marked_read_spec.rb
@@ -15,7 +15,7 @@ feature "User receives a message from a client" do
       clientone_id = Client.find_by(phone_number: clientone_phone).id
       visit client_messages_path(client_id: clientone_id)
       # post a message to the twilio endpoint from the user
-      twilio_post_sms(twilio_new_message_params(clientone.phone_number))
+      twilio_post_sms(twilio_new_message_params(from_number: clientone.phone_number))
       # there's a message with the correct contents
       expect(page).to have_css '.message--inbound p', text: twilio_message_text, wait: 10
       wait_for_ajax

--- a/spec/features/user_sends_message_to_client_spec.rb
+++ b/spec/features/user_sends_message_to_client_spec.rb
@@ -19,7 +19,7 @@ feature "User enters a message and submits it" do
     # the submit button is hidden
     find('#message_body').native.send_keys :enter
     # find the message on the page
-    expect(page).to have_css '.message--outbound p', text: message_body
+    expect(page).to have_css '.message--outbound div', text: message_body
     # get the message object and find the dom_id
     mymessage = Message.find_by(user: myuser, client_id: myclient_id, body: message_body)
     expect(page).to have_css '.message--outbound', id: dom_id(mymessage)

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Message, type: :model do
   let!(:message) { create :message, :user => user, :client => client}
 
   describe 'relationship to client' do
-    it 'belings to a client' do
+    it 'belongs to a client' do
       expect(message.client).to eq(client)
     end
   end
@@ -16,4 +16,34 @@ RSpec.describe Message, type: :model do
       expect(message.user).to eq(user)
     end
   end
+
+  describe '#create_from_twilio' do
+    it 'errors if no client matches the passed phone number' do
+      params = twilio_new_message_params '+99999999999'
+      expect {
+        Message.create_from_twilio!(params)
+      }.to raise_exception ActiveRecord::RecordNotFound
+    end
+
+    it 'creates a message if proper params are sent' do
+      params = twilio_new_message_params client.phone_number
+      msg = Message.create_from_twilio!(params)
+      expect(client.messages.last).to eq msg
+    end
+
+    it 'creates a message with attachments' do
+      params = twilio_new_message_params(
+        client.phone_number, nil, nil, 2
+      )
+      msg = Message.create_from_twilio!(params)
+      expect(msg).not_to eq nil
+      atts = msg.attachments.all
+      expect(atts.length).to eq 2
+      urls = atts.map(&:url)
+      types = atts.map(&:content_type)
+      expect(urls).to match_array(params.fetch_values('MediaUrl0', 'MediaUrl1'))
+      expect(types).to match_array(params.fetch_values('MediaContentType0', 'MediaContentType1'))
+    end
+  end
+
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -19,21 +19,21 @@ RSpec.describe Message, type: :model do
 
   describe '#create_from_twilio' do
     it 'errors if no client matches the passed phone number' do
-      params = twilio_new_message_params '+99999999999'
+      params = twilio_new_message_params from_number: '+99999999999'
       expect {
         Message.create_from_twilio!(params)
       }.to raise_exception ActiveRecord::RecordNotFound
     end
 
     it 'creates a message if proper params are sent' do
-      params = twilio_new_message_params client.phone_number
+      params = twilio_new_message_params from_number: client.phone_number
       msg = Message.create_from_twilio!(params)
       expect(client.messages.last).to eq msg
     end
 
     it 'creates a message with attachments' do
       params = twilio_new_message_params(
-        client.phone_number, nil, nil, 2
+        from_number: client.phone_number, media_count: 2
       )
       msg = Message.create_from_twilio!(params)
       expect(msg).not_to eq nil

--- a/spec/requests/messages_analytics_spec.rb
+++ b/spec/requests/messages_analytics_spec.rb
@@ -8,11 +8,14 @@ describe 'Tracking of message analytics events', type: :request do
         user = create :user
         sign_in user
         clientone = create_client build(:client)
-        create :message, user: user, client: clientone, inbound: true
-        create :message, user: user, client: clientone, inbound: true
+        msgone = create :message, user: user, client: clientone, inbound: true
+        msgtwo = create :message, user: user, client: clientone, inbound: true
         create :message, user: user, client: clientone, inbound: true
         create :message, user: user, client: clientone, inbound: false
         create :message, user: user, client: clientone, inbound: true
+        create :attachment, message: msgone
+        create :attachment, message: msgone
+        create :attachment, message: msgtwo
       end
       get client_messages_path clientone
       expect(response.code).to eq '200'
@@ -24,7 +27,8 @@ describe 'Tracking of message analytics events', type: :request do
           'hours_since_contact' => 3,
           'messages_all_count' => 5,
           'messages_received_count' => 4,
-          'messages_sent_count' => 1
+          'messages_sent_count' => 1,
+          'messages_attachments_count' => 3
         }
       })
     end

--- a/spec/requests/twilio_analytics_spec.rb
+++ b/spec/requests/twilio_analytics_spec.rb
@@ -16,7 +16,30 @@ describe 'Tracking of twilio analytics events', type: :request do
       expect_analytics_events({
         'message_receive' => {
           'client_id' => clientone.id,
-          'message_length' => message_text.length
+          'message_length' => message_text.length,
+          'attachments_count' => 0
+        }
+      })
+    end
+
+    it 'tracks an incoming sms message with an attachment' do
+      user = create :user
+      sign_in user
+      clientone = create_client build(:client)
+      # post a new message with an attachment
+      message_text = 'Hello, this is a new message from a client!'
+      message_params = twilio_new_message_params(
+        from_number: clientone.phone_number,
+        msg_txt: message_text,
+        media_count: 1
+      )
+      twilio_post_sms message_params
+      # validate the analytics event
+      expect_analytics_events({
+        'message_receive' => {
+          'client_id' => clientone.id,
+          'message_length' => message_text.length,
+          'attachments_count' => 1
         }
       })
     end

--- a/spec/requests/twilio_analytics_spec.rb
+++ b/spec/requests/twilio_analytics_spec.rb
@@ -9,7 +9,7 @@ describe 'Tracking of twilio analytics events', type: :request do
       # post a new message
       message_text = 'Hello, this is a new message from a client!'
       message_params = twilio_new_message_params(
-        clientone.phone_number, nil, message_text
+        from_number: clientone.phone_number, msg_txt: message_text
       )
       twilio_post_sms message_params
       # validate the analytics event

--- a/spec/requests/twilio_spec.rb
+++ b/spec/requests/twilio_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe 'Twilio controller', type: :request do
+  context 'POST#incoming_sms' do
+    it 'receives an incoming sms message' do
+      user = create :user
+      sign_in user
+      clientone = create_client build(:client)
+      # post a new message
+      message_text = 'Hello, this is a new message from a client!'
+      message_params = twilio_new_message_params(
+        clientone.phone_number, nil, message_text
+      )
+      twilio_post_sms message_params
+      msg = user.messages.last
+      expect(msg).not_to eq nil
+      expect(msg.body).to eq message_text
+    end
+
+    it 'receives an incoming sms message with an attachment' do
+      user = create :user
+      sign_in user
+      clientone = create_client build(:client)
+      # post a new message
+      message_text = 'Hello, this is a new message from a client!'
+      message_params = twilio_new_message_params(
+        clientone.phone_number, nil, message_text, 2
+      )
+      twilio_post_sms message_params
+      msg = user.messages.last
+      expect(msg).not_to eq nil
+      expect(msg.body).to eq message_text
+      atts = msg.attachments.all
+      expect(atts.length).to eq 2
+    end
+  end
+end
+

--- a/spec/requests/twilio_spec.rb
+++ b/spec/requests/twilio_spec.rb
@@ -16,23 +16,6 @@ describe 'Twilio controller', type: :request do
       expect(msg).not_to eq nil
       expect(msg.body).to eq message_text
     end
-
-    it 'receives an incoming sms message with an attachment' do
-      user = create :user
-      sign_in user
-      clientone = create_client build(:client)
-      # post a new message
-      message_text = 'Hello, this is a new message from a client!'
-      message_params = twilio_new_message_params(
-        clientone.phone_number, nil, message_text, 2
-      )
-      twilio_post_sms message_params
-      msg = user.messages.last
-      expect(msg).not_to eq nil
-      expect(msg.body).to eq message_text
-      atts = msg.attachments.all
-      expect(atts.length).to eq 2
-    end
   end
 end
 

--- a/spec/requests/twilio_spec.rb
+++ b/spec/requests/twilio_spec.rb
@@ -9,7 +9,7 @@ describe 'Twilio controller', type: :request do
       # post a new message
       message_text = 'Hello, this is a new message from a client!'
       message_params = twilio_new_message_params(
-        clientone.phone_number, nil, message_text
+        from_number: clientone.phone_number, msg_txt: message_text
       )
       twilio_post_sms message_params
       msg = user.messages.last

--- a/spec/support/twilio_helper.rb
+++ b/spec/support/twilio_helper.rb
@@ -26,10 +26,10 @@ module TwilioHelper
   end
 
   def twilio_new_message_params(
-    from_number = '+12425551212',
-    sms_sid = SecureRandom.hex(17),
-    msg_txt = twilio_message_text,
-    media_count = 0
+    from_number: '+12425551212',
+    sms_sid: SecureRandom.hex(17),
+    msg_txt: twilio_message_text,
+    media_count: 0
   )
     HashWithIndifferentAccess.new({
       "ToCountry"=>"US",

--- a/spec/support/twilio_helper.rb
+++ b/spec/support/twilio_helper.rb
@@ -28,7 +28,8 @@ module TwilioHelper
   def twilio_new_message_params(
     from_number = '+12425551212',
     sms_sid = SecureRandom.hex(17),
-    msg_txt = twilio_message_text
+    msg_txt = twilio_message_text,
+    media_count = 0
   )
     {
       "ToCountry"=>"US",
@@ -53,7 +54,22 @@ module TwilioHelper
       "ApiVersion"=>"2010-04-01",
       "controller"=>"twilio",
       "action"=>"incoming_sms"
-    }
+    }.merge(generate_media_parameters(media_count))
+  end
+
+  def generate_media_parameters(count)
+    params = count > 0 ? {"NumMedia": count.to_s} : {}
+    (1..count).each do |i|
+      num = (i - 1).to_s
+      content_type = ["image/jpeg", "image/png", "image/gif"].sample
+      url = "https://api.twilio.com/2010-04-01/Accounts/" + SecureRandom.hex(17) +
+        "/Messages/" + SecureRandom.hex(17) +
+        "/Media/" + SecureRandom.hex(17)
+      params = params.merge(
+        {"MediaContentType#{num}": content_type, "MediaUrl#{num}": url}
+      )
+    end
+    params
   end
 
   def twilio_status_update_params(

--- a/spec/support/twilio_helper.rb
+++ b/spec/support/twilio_helper.rb
@@ -58,7 +58,7 @@ module TwilioHelper
   end
 
   def generate_media_parameters(count)
-    params = count > 0 ? {"NumMedia": count.to_s} : {}
+    params = count > 0 ? {"NumMedia" => count.to_s} : {}
     (1..count).each do |i|
       num = (i - 1).to_s
       content_type = ["image/jpeg", "image/png", "image/gif"].sample
@@ -66,7 +66,7 @@ module TwilioHelper
         "/Messages/" + SecureRandom.hex(17) +
         "/Media/" + SecureRandom.hex(17)
       params = params.merge(
-        {"MediaContentType#{num}": content_type, "MediaUrl#{num}": url}
+        {"MediaContentType#{num}" => content_type, "MediaUrl#{num}" => url}
       )
     end
     params

--- a/spec/support/twilio_helper.rb
+++ b/spec/support/twilio_helper.rb
@@ -31,7 +31,7 @@ module TwilioHelper
     msg_txt = twilio_message_text,
     media_count = 0
   )
-    {
+    HashWithIndifferentAccess.new({
       "ToCountry"=>"US",
       "ToState"=>"CA",
       "SmsMessageSid"=>sms_sid,
@@ -54,7 +54,7 @@ module TwilioHelper
       "ApiVersion"=>"2010-04-01",
       "controller"=>"twilio",
       "action"=>"incoming_sms"
-    }.merge(generate_media_parameters(media_count))
+    }.merge(generate_media_parameters(media_count)))
   end
 
   def generate_media_parameters(count)

--- a/spec/support/twilio_helper.rb
+++ b/spec/support/twilio_helper.rb
@@ -1,8 +1,13 @@
 module TwilioHelper
   def twilio_post_sms(tw_params = twilio_new_message_params)
-    post_sig = correct_signature(tw_params)
-    post_url = '/incoming/sms'
-    post_header_name = 'X-Twilio-Signature'
+    twilio_post tw_params, correct_signature(tw_params), '/incoming/sms'
+  end
+
+  def twilio_post_sms_status(tw_params = twilio_status_update_params)
+    twilio_post tw_params, correct_signature(tw_params), '/incoming/sms/status'
+  end
+
+  def twilio_post(tw_params, post_sig, post_url)
     if Capybara.current_session.server
       conn = Faraday.new("#{myhost}")
       conn.post do |req|
@@ -16,6 +21,16 @@ module TwilioHelper
     else
       post post_url, params: tw_params, headers: {post_header_name => post_sig}
     end
+  end
+
+  def twilio_clear_after
+    if defined?(page)
+      page.driver.header post_header_name, nil
+    end
+  end
+
+  def post_header_name
+    'X-Twilio-Signature'
   end
 
   def twilio_message_text
@@ -50,6 +65,25 @@ module TwilioHelper
       "ApiVersion"=>"2010-04-01",
       "controller"=>"twilio",
       "action"=>"incoming_sms"
+    }
+  end
+
+  def twilio_status_update_params(
+    from_number = '+12425551212',
+    sms_sid = SecureRandom.hex(17),
+    sms_status = 'delivered'
+  )
+    {
+      "SmsSid"=>sms_sid,
+      "SmsStatus"=>sms_status,
+      "MessageStatus"=>sms_status,
+      "To"=>"+12435551212",
+      "MessageSid"=>sms_sid,
+      "AccountSid"=>"077541f41cce52ea6c4944fa6823a4a277",
+      "From"=>from_number,
+      "ApiVersion"=>"2010-04-01",
+      "controller"=>"twilio",
+      "action"=>"incoming_sms_status"
     }
   end
 

--- a/spec/support/twilio_helper.rb
+++ b/spec/support/twilio_helper.rb
@@ -59,14 +59,13 @@ module TwilioHelper
 
   def generate_media_parameters(count)
     params = count > 0 ? {"NumMedia" => count.to_s} : {}
-    (1..count).each do |i|
-      num = (i - 1).to_s
+    count.times.each do |i|
       content_type = ["image/jpeg", "image/png", "image/gif"].sample
       url = "https://api.twilio.com/2010-04-01/Accounts/" + SecureRandom.hex(17) +
         "/Messages/" + SecureRandom.hex(17) +
         "/Media/" + SecureRandom.hex(17)
       params = params.merge(
-        {"MediaContentType#{num}" => content_type, "MediaUrl#{num}" => url}
+        {"MediaContentType#{i}" => content_type, "MediaUrl#{i}" => url}
       )
     end
     params


### PR DESCRIPTION
Displays image attachments in received messages; tracks attachments; improves Twilio testing.

### Next steps/improvements needed (beyond the scope of this PR)
- late image loading messes with the scroll position of the message window
- get and save attachment image dimensions
- save images to an s3 bucket and securely reference them there
- delete images from Twilio when they're stored on s3
- generate smaller versions of images for display on desktop & mobile
- clicking on image downloads original to disk(?)

Closes  #35
