### PR TITLE
Adds phone number to navbar, resolves #36

### DIFF
--- a/app/assets/stylesheets/organisms/_main-header.scss
+++ b/app/assets/stylesheets/organisms/_main-header.scss
@@ -14,12 +14,18 @@
   margin-bottom: 0;
   font-weight: 500;
   color: #666;
+
   .main-header__site-title {
     color: #666;    
     font-size: $font-size-normal;
     text-decoration: none;
     margin-right: .3em;
   }
+
+  .user-phone-number {
+    padding-left: .3em;
+  }
+
   .main-header__cbo-title {
     display: inline-block;
     @include media($tablet-up) {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,14 @@
 class ApplicationController < ActionController::Base
   include AnalyticsHelper
-  
+
   protect_from_forgery with: :exception
   before_action :set_visitor_id
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_filter :set_phone_number
+
+  def set_phone_number
+    @user_phone_number = PhoneNumberParser.format_for_display(ENV['TWILIO_PHONE_NUMBER'])
+  end
 
   private
 
@@ -13,6 +18,7 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:full_name])
   end
+
 
   # ANALYTICS
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :set_visitor_id
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_filter :set_phone_number
+  before_action :set_phone_number
 
   private
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,9 +6,6 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_filter :set_phone_number
 
-  def set_phone_number
-    @user_phone_number = PhoneNumberParser.format_for_display(ENV['TWILIO_PHONE_NUMBER'])
-  end
 
   private
 
@@ -24,5 +21,12 @@ class ApplicationController < ActionController::Base
 
   def set_visitor_id
     session[:visitor_id] ||= SecureRandom.hex(4)
+  end
+
+
+  # COMMON
+
+  def set_phone_number
+    @clientcomm_phone_number ||= PhoneNumberParser.format_for_display(ENV['TWILIO_PHONE_NUMBER'])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_filter :set_phone_number
 
-
   private
 
   # DEVISE
@@ -16,13 +15,11 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:full_name])
   end
 
-
   # ANALYTICS
 
   def set_visitor_id
     session[:visitor_id] ||= SecureRandom.hex(4)
   end
-
 
   # COMMON
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
             <h1 class="toolbar__item main-header__title">
               <a class="main-header__site-title" href="/">ClientComm</a>
               <span class="label label--magenta">Beta</span>
-              <span class="user-phone-number is-mobile-hidden--inline">&nbsp<%= @clientcomm_phone_number %></span>
+              <span class="user-phone-number is-mobile-hidden--inline"><%= @clientcomm_phone_number %></span>
             </h1>
           </div>
           <div class="toolbar__right text--small">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,11 @@
       <header class="main-header">
         <div class="toolbar">
           <div class="toolbar__left">
-            <h1 class="toolbar__item main-header__title"><a class="main-header__site-title" href="/">ClientComm</a><span class="label label--magenta">Beta</span></h1> 
+            <h1 class="toolbar__item main-header__title">
+              <a class="main-header__site-title" href="/">ClientComm</a>
+              <span class="user-phone-number is-mobile-hidden--inline"> | <%= @user_phone_number %></span>
+              <span class="label label--magenta">Beta</span>
+            </h1>
           </div>
           <div class="toolbar__right text--small">
             <% if user_signed_in? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,8 +25,8 @@
           <div class="toolbar__left">
             <h1 class="toolbar__item main-header__title">
               <a class="main-header__site-title" href="/">ClientComm</a>
-              <span class="user-phone-number is-mobile-hidden--inline"> | <%= @user_phone_number %></span>
               <span class="label label--magenta">Beta</span>
+              <span class="user-phone-number is-mobile-hidden--inline">&nbsp<%= @clientcomm_phone_number %></span>
             </h1>
           </div>
           <div class="toolbar__right text--small">

--- a/spec/features/user_visits_clients_page_spec.rb
+++ b/spec/features/user_visits_clients_page_spec.rb
@@ -2,9 +2,12 @@ require "rails_helper"
 
 feature "logged-out user visits clients page" do
   scenario "and is redirected to the login form" do
+
     visit clients_path
     expect(page).to have_text "Log in"
+    expect(page).to have_text PhoneNumberParser.format_for_display(ENV['TWILIO_PHONE_NUMBER'])
     expect(page).to have_current_path(new_user_session_path)
+
   end
 end
 

--- a/spec/features/user_visits_clients_page_spec.rb
+++ b/spec/features/user_visits_clients_page_spec.rb
@@ -2,12 +2,10 @@ require "rails_helper"
 
 feature "logged-out user visits clients page" do
   scenario "and is redirected to the login form" do
-
     visit clients_path
     expect(page).to have_text "Log in"
     expect(page).to have_text PhoneNumberParser.format_for_display(ENV['TWILIO_PHONE_NUMBER'])
     expect(page).to have_current_path(new_user_session_path)
-
   end
 end
 


### PR DESCRIPTION
Add the user's phone number to the navbar so that they can give it out to clients. Number is hidden on mobile to prevent wrapping.