### PR TITLE
Add validation errors for clients/new and add uniqueness for phone numbers

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -24,13 +24,17 @@ class ClientsController < ApplicationController
   end
 
   def create
-    client = current_user.clients.create(client_params)
+    @client = current_user.clients.create(client_params)
 
-    analytics_track(
-      label: 'client_create_success',
-      data: client.analytics_tracker_data
-    )
-    redirect_to clients_path
+    if @client.valid?
+      analytics_track(
+          label: 'client_create_success',
+          data: @client.analytics_tracker_data
+      )
+      redirect_to clients_path
+    else
+      render :new
+    end
   end
 
   def edit

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -6,7 +6,7 @@ class Client < ApplicationRecord
   validates :last_name, :presence => true
   validates :birth_date, :presence => true
   validates :phone_number, presence: true
-  validates_uniqueness_of :phone_number, message: 'This phone number already belongs to a client in ClientComm. Need help? Chat with us by clicking the green chat button in the bottom-right of your screen.'
+  validates_uniqueness_of :phone_number, message: 'Phone number is already in use. If you need help, you can click the chat button at the bottom of your screen.'
 
   def analytics_tracker_data
     {

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -5,7 +5,8 @@ class Client < ApplicationRecord
 
   validates :last_name, :presence => true
   validates :birth_date, :presence => true
-  validates :phone_number, :presence => true
+  validates :phone_number, presence: true
+  validates_uniqueness_of :phone_number, message: 'This phone number already belongs to a client in ClientComm. Need help? Chat with us by clicking the green chat button in the bottom-right of your screen.'
 
   def analytics_tracker_data
     {

--- a/spec/features/user_creates_client_spec.rb
+++ b/spec/features/user_creates_client_spec.rb
@@ -9,16 +9,26 @@ feature "logged-out user visits create client page" do
 end
 
 feature "User creates client" do
-  scenario "successfully" do
-    # log in with a fake user
+  before do
     myuser = create :user
     login_as(myuser, :scope => :user)
     visit root_path
-    click_on "New client"
+    click_on 'New client'
     expect(page).to have_current_path(new_client_path)
+  end
+
+  scenario 'successfully' do
     myclient = build :client
     add_client(myclient)
     expect(page).to have_css '.data-table td', text: myclient.full_name
     expect(page).to have_current_path(clients_path)
+  end
+
+  scenario 'unsuccessfully' do
+    myclient = build :client, last_name: nil
+
+    add_client(myclient)
+    expect(page).to have_content 'Add a new client'
+    expect(page).to have_content "Last name can't be blank"
   end
 end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -2,26 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Client, type: :model do
   describe 'relationships' do
-    let!(:user) { create :user }
-    let!(:client) { create :client, :user => user }
-    let!(:message) { create :message, :user => user, :client => client}
-
-    describe 'relationship to user' do
-      it 'belongs to a user' do
-        expect(client.user).to eq(user)
-      end
-    end
-
-    describe 'relationship to message' do
-      it 'has a message' do
-        expect(message.client).to eq(client)
-      end
-    end
+    it {
+      should belong_to(:user)
+      should have_many(:messages)
+    }
   end
 
   describe 'accessors' do
-    let!(:user) { create :user }
-    subject { create :client, :user => user }
+    subject { create :client }
 
     describe '#full_name' do
       it 'formats full name' do
@@ -47,6 +35,13 @@ RSpec.describe Client, type: :model do
       client = Client.new(last_name: 'Last', birth_date: DateTime.now)
       expect(client.valid?).to be_falsey
       expect([:phone_number]).to eql client.errors.keys
+    end
+
+    it 'validates uniqueness of phone_number' do
+      old_client = create(:client)
+      new_client = build(:client, phone_number: old_client.phone_number)
+      expect(new_client.valid?).to be_falsey
+      expect([:phone_number]).to eql new_client.errors.keys
     end
   end
 

--- a/spec/requests/clients_analytics_spec.rb
+++ b/spec/requests/clients_analytics_spec.rb
@@ -47,21 +47,6 @@ describe 'Tracking of client analytics events', type: :request do
     end
   end
 
-  context 'POST#new' do
-    it 'tracks the creation of a new client' do
-      user = create :user
-      sign_in user
-      clientone = create_client build(:client)
-      expect(response.code).to eq '302'
-      expect_analytics_events({
-        'client_create_success' => {
-          'client_id' => clientone.id,
-          'has_client_dob' => true
-        }
-      })
-    end
-  end
-
   context 'GET#edit' do
     it 'tracks a visit to the edit client form' do
       userone = create :user

--- a/spec/requests/clients_request_spec.rb
+++ b/spec/requests/clients_request_spec.rb
@@ -62,6 +62,19 @@ describe 'Access to clients methods', type: :request do
           expect(response).to redirect_to clients_path
           expect(Client.count).to eq 1
         end
+
+        it 'tracks the creation of a new client' do
+          created_client = Client.find_by(phone_number: client.phone_number)
+
+          expect_analytics_events(
+              {
+                  'client_create_success' => {
+                      'client_id' => created_client.id,
+                      'has_client_dob' => true
+                  }
+              }
+          )
+        end
       end
 
       context 'invalid client' do

--- a/spec/requests/clients_request_spec.rb
+++ b/spec/requests/clients_request_spec.rb
@@ -32,20 +32,46 @@ describe 'Access to clients methods', type: :request do
   end
 
   context 'POST#create' do
-    it 'rejects unauthenticated user' do
-      create_client build(:client)
-      expect(response.code).to eq '302'
-      expect(response).to redirect_to new_user_session_path
-      expect(Client.count()).to eq 0
+    context 'unauthenticated user' do
+      let(:client) {build(:client)}
+
+      before do
+        create_client client
+      end
+
+      it 'rejects unauthenticated user' do
+        expect(response.code).to eq '302'
+        expect(response).to redirect_to new_user_session_path
+        expect(Client.count).to eq 0
+      end
     end
 
-    it 'allows authenticated user' do
-      user = create :user
-      sign_in user
-      create_client build(:client)
-      expect(response.code).to eq '302'
-      expect(response).to redirect_to clients_path
-      expect(Client.count()).to eq 1
+    context 'authenticated user' do
+      before do
+        user = create :user
+        sign_in user
+
+        create_client client
+      end
+
+      context 'valid client' do
+        let(:client) { build(:client) }
+
+        it 'creates a client' do
+          expect(response.code).to eq '302'
+          expect(response).to redirect_to clients_path
+          expect(Client.count).to eq 1
+        end
+      end
+
+      context 'invalid client' do
+        let(:client) { build(:client, last_name: nil) }
+
+        it 'renders new with validation errors' do
+          expect(response.code).to eq '200'
+          expect(Client.count).to eq 0
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves #77

https://waffle.io/codeforamerica/clientcomm-project/cards/595d241f49355c008011411b

 - Add error handling for clients/new page to prevent 500 errors
 - Consolidate controller level tests