### PR TITLE
Message styling

### DIFF
--- a/app/assets/stylesheets/templates/_messages.scss
+++ b/app/assets/stylesheets/templates/_messages.scss
@@ -40,12 +40,14 @@
         margin-bottom: 10px;
         padding: {
           bottom: .5em;
-          left: $padding-small;
-          right: $padding-small;
+          left: 1.5em;
+          right: 1.5em;
           top: $padding-small;
         }
         display: inline-block;
-        max-width: 60%;
+        @include media($mobile-up){
+          max-width: 60%;
+        }
         float: right;
       }
 
@@ -76,9 +78,12 @@
         margin-bottom: 10px;
         padding: {
           bottom: .5em;
-          left: $padding-small;
-          right: $padding-small;
+          left: 1.5em;
+          right: 1.5em;
           top: $padding-small;
+        }
+        @include media($mobile-up){
+          max-width: 60%;
         }
         display: inline-block;
       }

--- a/app/assets/stylesheets/templates/_messages.scss
+++ b/app/assets/stylesheets/templates/_messages.scss
@@ -18,8 +18,6 @@
   }
 
   .message--container {
-    display: flex;
-    flex-wrap: wrap;
     justify-content: space-between;
     margin-bottom: 1em;
     max-width: 750px;
@@ -28,12 +26,14 @@
       height: auto;
       max-width: 100%;
     }
-
-    .message--outbound {
+    .message {
       width: 100%;
+    }
+    .message--outbound {
       margin-left: auto;
 
       .message--content {
+        max-width: 100%;
         background: $color-teal;
         border-radius: 10px 10px 0px 10px;
         color: $color-background;
@@ -69,10 +69,11 @@
     }
 
     .message--inbound {
-      align-self: flex-start;
       width: 100%;
+      display: inline-block;
 
       .message--content {
+        max-width: 100%;
         background: $color-light-grey;
         border-radius: 10px 10px 10px 0px;
         margin-bottom: 10px;

--- a/app/assets/stylesheets/templates/_messages.scss
+++ b/app/assets/stylesheets/templates/_messages.scss
@@ -26,7 +26,7 @@
       height: auto;
       max-width: 100%;
     }
-    
+
     .message--outbound {
       margin-left: auto;
 

--- a/app/assets/stylesheets/templates/_messages.scss
+++ b/app/assets/stylesheets/templates/_messages.scss
@@ -26,9 +26,7 @@
       height: auto;
       max-width: 100%;
     }
-    .message {
-      width: 100%;
-    }
+    
     .message--outbound {
       margin-left: auto;
 

--- a/app/assets/stylesheets/templates/_messages.scss
+++ b/app/assets/stylesheets/templates/_messages.scss
@@ -26,7 +26,7 @@
       height: auto;
       max-width: 100%;
     }
-    
+
     .message--outbound {
       margin-left: auto;
 
@@ -38,8 +38,8 @@
         margin-bottom: 10px;
         padding: {
           bottom: .5em;
-          left: 1.5em;
-          right: 1.5em;
+          left: $padding-small;
+          right: $padding-small;
           top: $padding-small;
         }
         display: inline-block;
@@ -77,8 +77,8 @@
         margin-bottom: 10px;
         padding: {
           bottom: .5em;
-          left: 1.5em;
-          right: 1.5em;
+          left: $padding-small;
+          right: $padding-small;
           top: $padding-small;
         }
         @include media($mobile-up){

--- a/app/assets/stylesheets/templates/_messages.scss
+++ b/app/assets/stylesheets/templates/_messages.scss
@@ -30,12 +30,12 @@
     }
 
     .message--outbound {
-      flex-basis: 55%;
+      width: 100%;
       margin-left: auto;
 
       .message--content {
         background: $color-teal;
-        border-radius: 8px;
+        border-radius: 10px 10px 0px 10px;
         color: $color-background;
         margin-bottom: 10px;
         padding: {
@@ -44,7 +44,9 @@
           right: $padding-small;
           top: $padding-small;
         }
-        text-align: right;
+        display: inline-block;
+        max-width: 60%;
+        float: right;
       }
 
       .message--label {
@@ -58,16 +60,19 @@
         padding: .5em;
         text-align: right;
         top: -.1em;
+        width: 100%;
+        display: block;
+        float: right;
       }
     }
 
     .message--inbound {
       align-self: flex-start;
-      flex-basis: 55%;
+      width: 100%;
 
       .message--content {
         background: $color-light-grey;
-        border-radius: 6px;
+        border-radius: 10px 10px 10px 0px;
         margin-bottom: 10px;
         padding: {
           bottom: .5em;
@@ -75,6 +80,7 @@
           right: $padding-small;
           top: $padding-small;
         }
+        display: inline-block;
       }
 
       .message--label {

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -2,5 +2,5 @@
   <div class="message--content"><%= message.body %>
   <%= render message.attachments %>
   </div>
-  <p class="message--label"><%= message.twilio_status %> <%= message.created_at.to_s(:message_timestamp) %></p>    
-</div>  
+  <p class="message--label"><%= message.twilio_status %> <%= message.created_at.to_s(:message_timestamp) %></p>
+</div>


### PR DESCRIPTION
Changes the layout of the message bubbles so that they are the width of the text that they contain (rather than being fixed width). On mobile, message bubbles will be 100% the width of the container.

Also removes the use of flexbox CSS, making the messages view compatible with older browsers. Small but important fix.

![screen shot 2017-07-10 at 1 39 18 pm](https://user-images.githubusercontent.com/1418949/28038884-40936dd2-6575-11e7-8a57-71fc91071047.png)
![screen shot 2017-07-10 at 1 39 34 pm](https://user-images.githubusercontent.com/1418949/28038885-40964a8e-6575-11e7-8b36-823731b9954c.png)

