### PR TITLE
Remove birth date field from clients

### DIFF
--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -66,7 +66,7 @@ class ClientsController < ApplicationController
 
   def client_params
     params.fetch(:client, {})
-      .permit(:first_name, :last_name, :birth_date, :phone_number, :active)
+      .permit(:first_name, :last_name, :phone_number, :active)
   end
 
   def sorted_clients

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -4,14 +4,12 @@ class Client < ApplicationRecord
   has_many :attachments, through: :messages
 
   validates :last_name, :presence => true
-  validates :birth_date, :presence => true
   validates :phone_number, presence: true
   validates_uniqueness_of :phone_number, message: 'Phone number is already in use. If you need help, you can click the chat button at the bottom of your screen.'
 
   def analytics_tracker_data
     {
       client_id: self.id,
-      has_client_dob: !self.birth_date.nil?,
       has_unread_messages: (unread_messages_count > 0),
       hours_since_contact: hours_since_contact,
       messages_all_count: messages.count,

--- a/app/views/clients/_form.html.erb
+++ b/app/views/clients/_form.html.erb
@@ -10,7 +10,6 @@
         <%= form_for @client, builder: GcfFormBuilder do |f| %>
           <%= f.gcf_input_field :first_name, "First name", autofocus: true, classes: ['form-width--name'] %>
           <%= f.gcf_input_field :last_name, "Last name", classes: ['form-width--name'] %>
-          <%= f.gcf_date_select :birth_date, "Date of birth", { options: { start_year: 1900, end_year: Time.now.year, default: Date.new(1990,1,15), order: [:month, :day, :year] } } %>
           <%= f.gcf_input_field :phone_number, "Phone number", notes: ['example: 2435551212'], classes: ['form-width--med'] %>
 
           <div class="form-card__footer">

--- a/db/migrate/20170718001857_remove_birth_date_from_clients.rb
+++ b/db/migrate/20170718001857_remove_birth_date_from_clients.rb
@@ -1,0 +1,5 @@
+class RemoveBirthDateFromClients < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :clients, :birth_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170714175419) do
+ActiveRecord::Schema.define(version: 20170718001857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,7 +27,6 @@ ActiveRecord::Schema.define(version: 20170714175419) do
   create_table "clients", force: :cascade do |t|
     t.string   "first_name"
     t.string   "last_name"
-    t.datetime "birth_date"
     t.string   "phone_number"
     t.boolean  "active",       default: true, null: false
     t.datetime "created_at",                  null: false

--- a/spec/factories/clients.rb
+++ b/spec/factories/clients.rb
@@ -3,11 +3,6 @@ FactoryGirl.define do
     user { create :user }
     sequence(:first_name) { |n| "Elsie#{n}" }
     sequence(:last_name) { |n| "Muller#{n}" }
-    birth_date do
-      from = 50.years.ago.to_f
-      to = 20.years.ago.to_f
-      Time.at(from + rand * (to - from))
-    end
     sequence(:phone_number) { |n| "243" + (n.to_s + (1000000 + Random.rand(10000000 - 1000000)).to_s)[0..6] }
     active true
   end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -28,11 +28,10 @@ RSpec.describe Client, type: :model do
   describe 'validations' do
     it {
       should validate_presence_of(:last_name)
-      should validate_presence_of(:birth_date)
     }
 
     it 'validates presence of phone_number' do
-      client = Client.new(last_name: 'Last', birth_date: DateTime.now)
+      client = Client.new(last_name: 'Last')
       expect(client.valid?).to be_falsey
       expect([:phone_number]).to eq client.errors.keys
     end

--- a/spec/requests/clients_analytics_spec.rb
+++ b/spec/requests/clients_analytics_spec.rb
@@ -69,8 +69,7 @@ describe 'Tracking of client analytics events', type: :request do
       expect(response.code).to eq '302'
       expect_analytics_events({
         'client_edit_success' => {
-          'client_id' => clientone.id,
-          'has_client_dob' => true
+          'client_id' => clientone.id
         }
       })
     end

--- a/spec/requests/clients_request_spec.rb
+++ b/spec/requests/clients_request_spec.rb
@@ -36,8 +36,7 @@ describe 'Clients requests', type: :request do
           expect_analytics_events(
               {
                   'client_create_success' => {
-                      'client_id' => created_client.id,
-                      'has_client_dob' => true
+                      'client_id' => created_client.id
                   }
               }
           )

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -12,9 +12,6 @@ module FeatureHelper
     visit new_client_path
     fill_in "First name", with: the_client.first_name
     fill_in "Last name", with: the_client.last_name
-    select Date::MONTHNAMES[the_client.birth_date.month], from: "client_birth_date_2i"
-    select the_client.birth_date.day.to_s, from: "client_birth_date_3i"
-    select the_client.birth_date.year.to_s, from: "client_birth_date_1i"
     fill_in "Phone number", with: the_client.phone_number
     click_on "Save new client"
     expect(page).to have_current_path(clients_path)

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -24,10 +24,7 @@ module RequestHelper
       client: {
         first_name: client.first_name,
         last_name: client.last_name,
-        phone_number: client.phone_number,
-        'birth_date(1i)': client.birth_date.year,
-        'birth_date(2i)': client.birth_date.month,
-        'birth_date(3i)': client.birth_date.day
+        phone_number: client.phone_number
       }
     }
     post clients_path, params: post_params
@@ -41,10 +38,7 @@ module RequestHelper
       client: {
         first_name: client.first_name,
         last_name: client.last_name,
-        phone_number: client.phone_number,
-        'birth_date(1i)': client.birth_date.year,
-        'birth_date(2i)': client.birth_date.month,
-        'birth_date(3i)': client.birth_date.day
+        phone_number: client.phone_number
       }
     }
     patch client_path(client_id), params: patch_params


### PR DESCRIPTION
From conversation with @alsomanya 
This field isn't used by anyone and we need to later make a more generic unique identifier for a client, probably configurable per deployment. Right now it's a required field that you can't even see in the application.