### PR TITLE
Fix for editing stale messages when receiving rapid webhook calls

### DIFF
--- a/app/controllers/twilio_controller.rb
+++ b/app/controllers/twilio_controller.rb
@@ -48,7 +48,8 @@ class TwilioController < ApplicationController
     return if message.nil?
 
     # update the status of the corresponding message in the database
-    message.update!(twilio_status: params[:SmsStatus])
+    # reload before `update` to avoid any DB race conditions from optimistic locking
+    message.reload.update!(twilio_status: params[:SmsStatus])
 
     # put the message broadcast in the queue
     MessageBroadcastJob.perform_later(message: message)


### PR DESCRIPTION
I am not thrilled with this fix, but I'm not sure what would be a better approach.

The way I understand this problem, there are some cases where a background task makes an update to a Message in the database **via another DB connection and ruby process** between lines 47 and 52 of this file.

The fix, then is simply to do a reload of the Message from the DB immediately before updating it on each of the relevant lines. A bit more work, but insures freshness!

An alternative would be to make the `update` lines into raw `UPDATE` SQL queries, which don't care about locking or object freshness at all. Downside is that this would bypass validations and other ActiveRecord callbacks, which might be important at some point.

Thoughts?

Relevant Sentry issue: https://sentry.io/codeforamerica/clientcomm/issues/352507556/