### PR TITLE
Limiting to 1000 messages for the conversation view.

### DIFF
--- a/app/controllers/reporting_relationships_controller.rb
+++ b/app/controllers/reporting_relationships_controller.rb
@@ -123,5 +123,6 @@ class ReportingRelationshipsController < ApplicationController
     @rr.messages
        .where('send_at < ?', Time.zone.now)
        .order('send_at ASC')
+       .limit(1000)
   end
 end


### PR DESCRIPTION
## What
There was a client reporting Heroku timeout errors. They have one conversation with 3400 messages. We assume the rendering of those is taking longer than the 30 seconds Heroku provides.

## Fix
Limiting the number of messages passed to a view to a 1000.

## Note
This PR **is live** in Mutlnomah County as a hotfix.